### PR TITLE
handle plurals in translations

### DIFF
--- a/i18n/lang_cs.ts
+++ b/i18n/lang_cs.ts
@@ -651,9 +651,17 @@ Continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
         <source>Using %1 thread(s)</source>
-        <translation>Používám %1 vlákno(a)</translation>
+        <translation type="vanished">Používám %1 vlákno(a)</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
+        <source>Using %n thread(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../src/BatchTM/BatchTMDialog.cpp" line="118"/>
@@ -4595,10 +4603,14 @@ p, li { white-space: pre-wrap; }
         <source>Temporary directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
+    <message numerus="yes">
         <location filename="../src/MainCli/commandline.cpp" line="403"/>
-        <source>Using %1 threads.</source>
-        <translation type="unfinished"></translation>
+        <source>Using %n threads.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../src/MainCli/commandline.cpp" line="417"/>

--- a/i18n/lang_da.ts
+++ b/i18n/lang_da.ts
@@ -696,9 +696,16 @@ Fortsæt?</translation>
         <translation>&amp;Start</translation>
     </message>
     <message>
-        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
         <source>Using %1 thread(s)</source>
-        <translation>Bruger %1 tråd(e)</translation>
+        <translation type="vanished">Bruger %1 tråd(e)</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
+        <source>Using %n thread(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../src/BatchTM/BatchTMDialog.cpp" line="118"/>
@@ -4893,10 +4900,17 @@ p, li { white-space: pre-wrap; }
         <source>Temporary directory: %1</source>
         <translation>Midlertidig mappe: %1</translation>
     </message>
-    <message>
+    <message numerus="yes">
         <location filename="../src/MainCli/commandline.cpp" line="403"/>
+        <source>Using %n threads.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
         <source>Using %1 threads.</source>
-        <translation>Bruger %1 tråde.</translation>
+        <translation type="vanished">Bruger %1 tråde.</translation>
     </message>
     <message>
         <location filename="../src/MainCli/commandline.cpp" line="417"/>

--- a/i18n/lang_de.ts
+++ b/i18n/lang_de.ts
@@ -696,9 +696,16 @@ Fortfahren?</translation>
         <translation>&amp;Starten</translation>
     </message>
     <message>
-        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
         <source>Using %1 thread(s)</source>
-        <translation>Benutze %1 Thread(s)</translation>
+        <translation type="vanished">Benutze %1 Thread(s)</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
+        <source>Using %n thread(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../src/BatchTM/BatchTMDialog.cpp" line="118"/>
@@ -4893,10 +4900,17 @@ p, li { white-space: pre-wrap; }
         <source>Temporary directory: %1</source>
         <translation>Temporärer Ordner: %1</translation>
     </message>
-    <message>
+    <message numerus="yes">
         <location filename="../src/MainCli/commandline.cpp" line="403"/>
+        <source>Using %n threads.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
         <source>Using %1 threads.</source>
-        <translation>Benutze %1 Thread(s).</translation>
+        <translation type="vanished">Benutze %1 Thread(s).</translation>
     </message>
     <message>
         <location filename="../src/MainCli/commandline.cpp" line="417"/>

--- a/i18n/lang_es.ts
+++ b/i18n/lang_es.ts
@@ -695,9 +695,16 @@ Continuamos?</translation>
         <translation>&amp;Inicio</translation>
     </message>
     <message>
-        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
         <source>Using %1 thread(s)</source>
-        <translation>Usando %1 hilo (thread)</translation>
+        <translation type="vanished">Usando %1 hilo (thread)</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
+        <source>Using %n thread(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../src/BatchTM/BatchTMDialog.cpp" line="118"/>
@@ -4785,10 +4792,17 @@ p, li { white-space: pre-wrap; }
         <source>Temporary directory: %1</source>
         <translation>Directorio temporal: %1</translation>
     </message>
-    <message>
+    <message numerus="yes">
         <location filename="../src/MainCli/commandline.cpp" line="403"/>
+        <source>Using %n threads.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
         <source>Using %1 threads.</source>
-        <translation>Utilizando %1 hilo.</translation>
+        <translation type="vanished">Utilizando %1 hilo.</translation>
     </message>
     <message>
         <location filename="../src/MainCli/commandline.cpp" line="417"/>

--- a/i18n/lang_fi.ts
+++ b/i18n/lang_fi.ts
@@ -654,9 +654,16 @@ Kuvaerän tonemappaus</translation>
         <translation>&amp;Aloita</translation>
     </message>
     <message>
-        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
         <source>Using %1 thread(s)</source>
-        <translation>Käytetään %1 säiettä</translation>
+        <translation type="vanished">Käytetään %1 säiettä</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
+        <source>Using %n thread(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../src/BatchTM/BatchTMDialog.cpp" line="118"/>
@@ -4691,10 +4698,17 @@ p, li { white-space: pre-wrap; }
         <source>Temporary directory: %1</source>
         <translation>Tilapäinen hakemisto: %1</translation>
     </message>
-    <message>
+    <message numerus="yes">
         <location filename="../src/MainCli/commandline.cpp" line="403"/>
+        <source>Using %n threads.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
         <source>Using %1 threads.</source>
-        <translation>Käytetään %1 säiettä.</translation>
+        <translation type="vanished">Käytetään %1 säiettä.</translation>
     </message>
     <message>
         <location filename="../src/MainCli/commandline.cpp" line="417"/>

--- a/i18n/lang_fr.ts
+++ b/i18n/lang_fr.ts
@@ -653,9 +653,16 @@ Continuer?</translation>
         <translation>&amp;Lancer</translation>
     </message>
     <message>
-        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
         <source>Using %1 thread(s)</source>
-        <translation>%1 processus en cours d&apos;utilisation</translation>
+        <translation type="vanished">%1 processus en cours d&apos;utilisation</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
+        <source>Using %n thread(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../src/BatchTM/BatchTMDialog.cpp" line="118"/>
@@ -4690,10 +4697,17 @@ p, li { white-space: pre-wrap; }
         <source>Temporary directory: %1</source>
         <translation>Dossier temporaire: %1</translation>
     </message>
-    <message>
+    <message numerus="yes">
         <location filename="../src/MainCli/commandline.cpp" line="403"/>
+        <source>Using %n threads.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
         <source>Using %1 threads.</source>
-        <translation>Utilisation de %1 threads.</translation>
+        <translation type="vanished">Utilisation de %1 threads.</translation>
     </message>
     <message>
         <location filename="../src/MainCli/commandline.cpp" line="417"/>

--- a/i18n/lang_hu.ts
+++ b/i18n/lang_hu.ts
@@ -651,9 +651,15 @@ Continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
         <source>Using %1 thread(s)</source>
-        <translation>%1 huzamot használ</translation>
+        <translation type="vanished">%1 huzamot használ</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
+        <source>Using %n thread(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../src/BatchTM/BatchTMDialog.cpp" line="118"/>
@@ -4567,10 +4573,12 @@ p, li { white-space: pre-wrap; }
         <source>Temporary directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
+    <message numerus="yes">
         <location filename="../src/MainCli/commandline.cpp" line="403"/>
-        <source>Using %1 threads.</source>
-        <translation type="unfinished"></translation>
+        <source>Using %n threads.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../src/MainCli/commandline.cpp" line="417"/>

--- a/i18n/lang_id.ts
+++ b/i18n/lang_id.ts
@@ -651,9 +651,15 @@ Continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
         <source>Using %1 thread(s)</source>
-        <translation>Menggunakan %1 thread(s)</translation>
+        <translation type="vanished">Menggunakan %1 thread(s)</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
+        <source>Using %n thread(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../src/BatchTM/BatchTMDialog.cpp" line="118"/>
@@ -4562,10 +4568,12 @@ p, li { white-space: pre-wrap; }
         <source>Temporary directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
+    <message numerus="yes">
         <location filename="../src/MainCli/commandline.cpp" line="403"/>
-        <source>Using %1 threads.</source>
-        <translation type="unfinished"></translation>
+        <source>Using %n threads.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../src/MainCli/commandline.cpp" line="417"/>

--- a/i18n/lang_it.ts
+++ b/i18n/lang_it.ts
@@ -663,9 +663,16 @@ Continuare?</translation>
         <translation>&amp;Avvia</translation>
     </message>
     <message>
-        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
         <source>Using %1 thread(s)</source>
-        <translation>Si utilizzano %1 thread(s)</translation>
+        <translation type="vanished">Si utilizzano %1 thread(s)</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
+        <source>Using %n thread(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../src/BatchTM/BatchTMDialog.cpp" line="118"/>
@@ -4701,10 +4708,17 @@ p, li { white-space: pre-wrap; }
         <source>Temporary directory: %1</source>
         <translation>Directory temporanea: %1</translation>
     </message>
-    <message>
+    <message numerus="yes">
         <location filename="../src/MainCli/commandline.cpp" line="403"/>
+        <source>Using %n threads.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
         <source>Using %1 threads.</source>
-        <translation>Utilizzando %1 threads.</translation>
+        <translation type="vanished">Utilizzando %1 threads.</translation>
     </message>
     <message>
         <location filename="../src/MainCli/commandline.cpp" line="417"/>

--- a/i18n/lang_pl.ts
+++ b/i18n/lang_pl.ts
@@ -650,10 +650,14 @@ Continue?</source>
         <source>&amp;Start</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
+    <message numerus="yes">
         <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
-        <source>Using %1 thread(s)</source>
-        <translation type="unfinished"></translation>
+        <source>Using %n thread(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../src/BatchTM/BatchTMDialog.cpp" line="118"/>
@@ -4549,10 +4553,14 @@ p, li { white-space: pre-wrap; }
         <source>Temporary directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
+    <message numerus="yes">
         <location filename="../src/MainCli/commandline.cpp" line="403"/>
-        <source>Using %1 threads.</source>
-        <translation type="unfinished"></translation>
+        <source>Using %n threads.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../src/MainCli/commandline.cpp" line="417"/>

--- a/i18n/lang_pt_BR.ts
+++ b/i18n/lang_pt_BR.ts
@@ -696,9 +696,16 @@ Continuar?</translation>
         <translation>&amp;Começar  </translation>
     </message>
     <message>
-        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
         <source>Using %1 thread(s)</source>
-        <translation>Usando %1 tópico(s)</translation>
+        <translation type="vanished">Usando %1 tópico(s)</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
+        <source>Using %n thread(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../src/BatchTM/BatchTMDialog.cpp" line="118"/>
@@ -4737,10 +4744,17 @@ p, li { white-space: pre-wrap; }
         <source>Temporary directory: %1</source>
         <translation>Diretório temporário: %1</translation>
     </message>
-    <message>
+    <message numerus="yes">
         <location filename="../src/MainCli/commandline.cpp" line="403"/>
+        <source>Using %n threads.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
         <source>Using %1 threads.</source>
-        <translation>Usando %1 tópicos.</translation>
+        <translation type="vanished">Usando %1 tópicos.</translation>
     </message>
     <message>
         <location filename="../src/MainCli/commandline.cpp" line="417"/>

--- a/i18n/lang_ro.ts
+++ b/i18n/lang_ro.ts
@@ -652,9 +652,17 @@ Continue?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
         <source>Using %1 thread(s)</source>
-        <translation>Folosind %1 fire de execuție</translation>
+        <translation type="vanished">Folosind %1 fire de execuție</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
+        <source>Using %n thread(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../src/BatchTM/BatchTMDialog.cpp" line="118"/>
@@ -4586,10 +4594,14 @@ p, li { white-space: pre-wrap; }
         <source>Temporary directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
+    <message numerus="yes">
         <location filename="../src/MainCli/commandline.cpp" line="403"/>
-        <source>Using %1 threads.</source>
-        <translation type="unfinished"></translation>
+        <source>Using %n threads.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../src/MainCli/commandline.cpp" line="417"/>

--- a/i18n/lang_ru.ts
+++ b/i18n/lang_ru.ts
@@ -655,9 +655,17 @@ Continue?</source>
         <translation>На&amp;чать</translation>
     </message>
     <message>
-        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
         <source>Using %1 thread(s)</source>
-        <translation>Используемых потоков: %1</translation>
+        <translation type="vanished">Используемых потоков: %1</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
+        <source>Using %n thread(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../src/BatchTM/BatchTMDialog.cpp" line="118"/>
@@ -4585,10 +4593,14 @@ p, li { white-space: pre-wrap; }
         <source>Temporary directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
+    <message numerus="yes">
         <location filename="../src/MainCli/commandline.cpp" line="403"/>
-        <source>Using %1 threads.</source>
-        <translation type="unfinished"></translation>
+        <source>Using %n threads.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../src/MainCli/commandline.cpp" line="417"/>

--- a/i18n/lang_tr.ts
+++ b/i18n/lang_tr.ts
@@ -660,9 +660,15 @@ Continue?</source>
         <translation>&amp;Başlat</translation>
     </message>
     <message>
-        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
         <source>Using %1 thread(s)</source>
-        <translation>% 1 konu kullanılıyor</translation>
+        <translation type="vanished">% 1 konu kullanılıyor</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
+        <source>Using %n thread(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../src/BatchTM/BatchTMDialog.cpp" line="118"/>
@@ -4670,10 +4676,12 @@ p, li { white-space: pre-wrap; }
         <source>Temporary directory: %1</source>
         <translation type="unfinished"></translation>
     </message>
-    <message>
+    <message numerus="yes">
         <location filename="../src/MainCli/commandline.cpp" line="403"/>
-        <source>Using %1 threads.</source>
-        <translation type="unfinished"></translation>
+        <source>Using %n threads.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../src/MainCli/commandline.cpp" line="417"/>

--- a/i18n/lang_zh.ts
+++ b/i18n/lang_zh.ts
@@ -660,9 +660,15 @@ Continue?</source>
         <translation>&amp;开始</translation>
     </message>
     <message>
-        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
         <source>Using %1 thread(s)</source>
-        <translation>使用%1 线程</translation>
+        <translation type="vanished">使用%1 线程</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/BatchTM/BatchTMDialog.cpp" line="98"/>
+        <source>Using %n thread(s)</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
     <message>
         <location filename="../src/BatchTM/BatchTMDialog.cpp" line="118"/>
@@ -4681,10 +4687,16 @@ p, li { white-space: pre-wrap; }
         <source>Temporary directory: %1</source>
         <translation>临时目录: %1</translation>
     </message>
-    <message>
+    <message numerus="yes">
         <location filename="../src/MainCli/commandline.cpp" line="403"/>
+        <source>Using %n threads.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
         <source>Using %1 threads.</source>
-        <translation>正在使用%1线程.</translation>
+        <translation type="vanished">正在使用%1线程.</translation>
     </message>
     <message>
         <location filename="../src/MainCli/commandline.cpp" line="417"/>

--- a/src/BatchTM/BatchTMDialog.cpp
+++ b/src/BatchTM/BatchTMDialog.cpp
@@ -95,7 +95,7 @@ BatchTMDialog::BatchTMDialog(QWidget *p):
     m_next_hdr_file = 0;
     m_is_batch_running  = false;
 
-    add_log_message(tr("Using %1 thread(s)").arg(m_max_num_threads));
+    add_log_message(tr("Using %n thread(s)", "", m_max_num_threads));
     //add_log_message(tr("Saving using file format: %1").arg(m_Ui->comboBoxFormat->currentText()));
 }
 

--- a/src/MainCli/commandline.cpp
+++ b/src/MainCli/commandline.cpp
@@ -400,7 +400,7 @@ void CommandLineInterfaceManager::execCommandLineParamsSlot()
             LuminanceOptions luminance_options;
 
             printIfVerbose(QObject::tr("Temporary directory: %1").arg(luminance_options.getTempDir()), verbose);
-            printIfVerbose(QObject::tr("Using %1 threads.").arg(luminance_options.getNumThreads()), verbose);
+            printIfVerbose(QObject::tr("Using %n threads.", "", luminance_options.getNumThreads()), verbose);
         }
         hdrCreationManager.reset( new HdrCreationManager(true) );
         connect(hdrCreationManager.data(), SIGNAL(finishedLoadingFiles()), this, SLOT(finishedLoadingInputFiles()));


### PR DESCRIPTION
Hi!
While working on Russian translation, I found a couple of strings with numbers that were not pluralized properly. I fixed them in code and updated *.ts files.