### PR TITLE
Fixed "undefined reference to pfs::Frame::getXYZChannels"

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -141,7 +141,7 @@ TARGET_LINK_LIBRARIES(TestFrameArray2D pfs
 ADD_TEST(TestFrameArray2D TestFrameArray2D)
 
 ADD_EXECUTABLE(TestFloatRgb TestFloatRgb.cpp)
-TARGET_LINK_LIBRARIES(TestFloatRgb common pfs fileformat
+TARGET_LINK_LIBRARIES(TestFloatRgb common fileformat pfs
     ${GTEST_BOTH_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
     ${LIBS})


### PR DESCRIPTION
This patch fixes TestFloatRgb target