### PR TITLE
Fixes locale problems in export to HTML (Issue #63)

### DIFF
--- a/src/HdrHTML/hdrhtml.cpp
+++ b/src/HdrHTML/hdrhtml.cpp
@@ -850,6 +850,9 @@ void HDRHTMLSet::generate_webpage( const char *page_template, const char *image_
   if( image_list.empty() )
     return;
 
+  string user_locale = locale("").name();
+  locale::global(locale::classic());
+
   ostringstream out_file_name;
   if (out_dir != NULL)
       out_file_name << out_dir << "/";
@@ -915,6 +918,7 @@ void HDRHTMLSet::generate_webpage( const char *page_template, const char *image_
     }
   }
 
+  locale::global(locale(user_locale.c_str()));
 }
 
 void print_image_objects( ostream &out, void *user_data, const char *parameter )


### PR DESCRIPTION
This should fix issue #63. Temporarily use C locale for the output to the HTML page. 
Solution inspired from existing code inside HDRHTMLSet::add_image, and replicated inside HDRHTMLSet::generate_webpage