### PR TITLE
speedup for mantiuk06 tmo

### DIFF
--- a/src/TonemappingOperators/mantiuk06/pfstmo_mantiuk06.cpp
+++ b/src/TonemappingOperators/mantiuk06/pfstmo_mantiuk06.cpp
@@ -46,7 +46,6 @@
 #include "Libpfs/frame.h"
 #include "Libpfs/pfs.h"
 #include "Libpfs/progress.h"
-#define BENCHMARK
 #include "StopWatch.h"
 
 //--- default tone mapping parameters;

--- a/src/TonemappingOperators/mantiuk06/pfstmo_mantiuk06.cpp
+++ b/src/TonemappingOperators/mantiuk06/pfstmo_mantiuk06.cpp
@@ -46,6 +46,8 @@
 #include "Libpfs/frame.h"
 #include "Libpfs/pfs.h"
 #include "Libpfs/progress.h"
+#define BENCHMARK
+#include "StopWatch.h"
 
 //--- default tone mapping parameters;
 // float scaleFactor = 0.1f;
@@ -61,6 +63,7 @@ const float tol = 5e-3f;
 void pfstmo_mantiuk06(pfs::Frame &frame, float scaleFactor,
                       float saturationFactor, float detailFactor, bool cont_eq,
                       pfs::Progress &ph) {
+BENCHFUN
 #ifndef NDEBUG
     std::stringstream ss;
 

--- a/src/TonemappingOperators/mantiuk06/pyramid.cpp
+++ b/src/TonemappingOperators/mantiuk06/pyramid.cpp
@@ -528,17 +528,11 @@ TransformToR::TransformToR(float detailFactor)
 
 // transform gradient G to R
 float TransformToR::operator()(float currG) const {
-    if (currG < 0.0f) {
-        // G to W
-        currG = pow_F(10, (-currG) * m_detailFactor) - 1.0f;
-        // W to RESP
-        return -lookup_table(LOOKUP_W_TO_R, W_table, R_table, currG);
-    } else {
-        // G to W
-        currG = pow_F(10, currG * m_detailFactor) - 1.0f;
-        // W to RESP
-        return lookup_table(LOOKUP_W_TO_R, W_table, R_table, currG);
-    }
+    const float mult = copysign(1.f, currG);
+    // G to W
+    currG = pow_F(10, (mult * currG) * m_detailFactor) - 1.0f;
+    // W to RESP
+    return mult * lookup_table(LOOKUP_W_TO_R, W_table, R_table, currG);
 }
 
 TransformToG::TransformToG(float detailFactor)
@@ -546,19 +540,11 @@ TransformToG::TransformToG(float detailFactor)
 
 // transform from R to G
 float TransformToG::operator()(float currR) const {
-    if (currR < 0.0f) {
-        // RESP to W
-        currR = lookup_table(LOOKUP_W_TO_R, R_table, W_table, -currR);
-        // W to G
-        // return -std::log(currR + 1.0f) * m_detailFactor;
-        return -std::log1p(currR) * m_detailFactor;  // avoid loss of precision
-    } else {
-        // RESP to W
-        currR = lookup_table(LOOKUP_W_TO_R, R_table, W_table, currR);
-        // W to G
-        // return std::log(currR + 1.0f) * m_detailFactor;
-        return std::log1p(currR) * m_detailFactor;  // avoid loss of precision
-    }
+    const float mult = copysign(1.f, currR);
+    // RESP to W
+    currR = lookup_table(LOOKUP_W_TO_R, R_table, W_table, mult * currR);
+    // W to G
+    return mult * std::log1p(currR) * m_detailFactor;  // avoid loss of precision
 }
 
 //! \brief calculate divergence of two gradient maps (Gx and Gy)

--- a/src/TonemappingOperators/mantiuk06/pyramid.cpp
+++ b/src/TonemappingOperators/mantiuk06/pyramid.cpp
@@ -26,6 +26,8 @@
 //! of the Mantiuk06 operator found in PFSTMO. However, the actual
 //! implementation found in this file (and its .cpp file) is based on STL
 //! containers
+#define BENCHMARK
+#include "../../StopWatch.h"
 
 #include "pyramid.h"
 
@@ -178,6 +180,7 @@ void PyramidT::transformToR(float detailFactor) {
 }
 
 void PyramidT::transformToG(float detailFactor) {
+BENCHFUN
     PyramidContainer::iterator itCurr = m_pyramid.begin();
     PyramidContainer::iterator itEnd = m_pyramid.end();
 
@@ -544,7 +547,7 @@ float TransformToG::operator()(float currR) const {
     // RESP to W
     currR = lookup_table(LOOKUP_W_TO_R, R_table, W_table, mult * currR);
     // W to G
-    return mult * std::log1p(currR) * m_detailFactor;  // avoid loss of precision
+    return mult * xlogf(1.f + currR) * m_detailFactor;
 }
 
 //! \brief calculate divergence of two gradient maps (Gx and Gy)

--- a/src/TonemappingOperators/mantiuk06/pyramid.cpp
+++ b/src/TonemappingOperators/mantiuk06/pyramid.cpp
@@ -42,6 +42,8 @@
 #include "Libpfs/array2d.h"
 #include "Libpfs/utils/numeric.h"
 #include "Libpfs/utils/sse.h"
+#include "../../sleef.c"
+#define pow_F(a,b) (xexpf(b*xlogf(a)))
 
 using namespace pfs;
 
@@ -528,12 +530,12 @@ TransformToR::TransformToR(float detailFactor)
 float TransformToR::operator()(float currG) const {
     if (currG < 0.0f) {
         // G to W
-        currG = std::pow(10, (-currG) * m_detailFactor) - 1.0f;
+        currG = pow_F(10, (-currG) * m_detailFactor) - 1.0f;
         // W to RESP
         return -lookup_table(LOOKUP_W_TO_R, W_table, R_table, currG);
     } else {
         // G to W
-        currG = std::pow(10, currG * m_detailFactor) - 1.0f;
+        currG = pow_F(10, currG * m_detailFactor) - 1.0f;
         // W to RESP
         return lookup_table(LOOKUP_W_TO_R, W_table, R_table, currG);
     }
@@ -605,7 +607,7 @@ static const float b = 0.537756f;
 
 float calculateScaleFactor(float g) {
 #if 1
-    return 1.0 / (a * std::pow(std::max(detectT, std::fabs(g)), b));
+    return 1.0 / (a * pow_F(std::max(detectT, std::fabs(g)), b));
 #else
     if (std::fabs(G[i]) < GFIXATE)
         C[i] = 1.0f / EDGE_WEIGHT;

--- a/src/TonemappingOperators/mantiuk06/pyramid.cpp
+++ b/src/TonemappingOperators/mantiuk06/pyramid.cpp
@@ -26,8 +26,6 @@
 //! of the Mantiuk06 operator found in PFSTMO. However, the actual
 //! implementation found in this file (and its .cpp file) is based on STL
 //! containers
-#define BENCHMARK
-#include "../../StopWatch.h"
 
 #include "pyramid.h"
 
@@ -51,10 +49,94 @@ using namespace pfs;
 
 namespace {
 inline size_t downscaleBy2(size_t value) { return (value >> 1); }
+const size_t PYRAMID_MIN_PIXELS = 3;
+
+const float LOG10FACTOR = 2.3025850929940456840179914546844f;
+const size_t LOOKUP_W_TO_R = 107;
+
+static float W_table[] = {
+    0.000000f,    0.010000f,    0.021180f,    0.031830f,    0.042628f,
+    0.053819f,    0.065556f,    0.077960f,    0.091140f,    0.105203f,
+    0.120255f,    0.136410f,    0.153788f,    0.172518f,    0.192739f,
+    0.214605f,    0.238282f,    0.263952f,    0.291817f,    0.322099f,
+    0.355040f,    0.390911f,    0.430009f,    0.472663f,    0.519238f,
+    0.570138f,    0.625811f,    0.686754f,    0.753519f,    0.826720f,
+    0.907041f,    0.995242f,    1.092169f,    1.198767f,    1.316090f,
+    1.445315f,    1.587756f,    1.744884f,    1.918345f,    2.109983f,
+    2.321863f,    2.556306f,    2.815914f,    3.103613f,    3.422694f,
+    3.776862f,    4.170291f,    4.607686f,    5.094361f,    5.636316f,
+    6.240338f,    6.914106f,    7.666321f,    8.506849f,    9.446889f,
+    10.499164f,   11.678143f,   13.000302f,   14.484414f,   16.151900f,
+    18.027221f,   20.138345f,   22.517282f,   25.200713f,   28.230715f,
+    31.655611f,   35.530967f,   39.920749f,   44.898685f,   50.549857f,
+    56.972578f,   64.280589f,   72.605654f,   82.100619f,   92.943020f,
+    105.339358f,  119.530154f,  135.795960f,  154.464484f,  175.919088f,
+    200.608905f,  229.060934f,  261.894494f,  299.838552f,  343.752526f,
+    394.651294f,  453.735325f,  522.427053f,  602.414859f,  695.706358f,
+    804.693100f,  932.229271f,  1081.727632f, 1257.276717f, 1463.784297f,
+    1707.153398f, 1994.498731f, 2334.413424f, 2737.298517f, 3215.770944f,
+    3785.169959f, 4464.187290f, 5275.653272f, 6247.520102f, 7414.094945f,
+    8817.590551f, 10510.080619f};
+static float R_table[] = {
+    0.000000f, 0.009434f, 0.018868f, 0.028302f, 0.037736f, 0.047170f, 0.056604f,
+    0.066038f, 0.075472f, 0.084906f, 0.094340f, 0.103774f, 0.113208f, 0.122642f,
+    0.132075f, 0.141509f, 0.150943f, 0.160377f, 0.169811f, 0.179245f, 0.188679f,
+    0.198113f, 0.207547f, 0.216981f, 0.226415f, 0.235849f, 0.245283f, 0.254717f,
+    0.264151f, 0.273585f, 0.283019f, 0.292453f, 0.301887f, 0.311321f, 0.320755f,
+    0.330189f, 0.339623f, 0.349057f, 0.358491f, 0.367925f, 0.377358f, 0.386792f,
+    0.396226f, 0.405660f, 0.415094f, 0.424528f, 0.433962f, 0.443396f, 0.452830f,
+    0.462264f, 0.471698f, 0.481132f, 0.490566f, 0.500000f, 0.509434f, 0.518868f,
+    0.528302f, 0.537736f, 0.547170f, 0.556604f, 0.566038f, 0.575472f, 0.584906f,
+    0.594340f, 0.603774f, 0.613208f, 0.622642f, 0.632075f, 0.641509f, 0.650943f,
+    0.660377f, 0.669811f, 0.679245f, 0.688679f, 0.698113f, 0.707547f, 0.716981f,
+    0.726415f, 0.735849f, 0.745283f, 0.754717f, 0.764151f, 0.773585f, 0.783019f,
+    0.792453f, 0.801887f, 0.811321f, 0.820755f, 0.830189f, 0.839623f, 0.849057f,
+    0.858491f, 0.867925f, 0.877358f, 0.886792f, 0.896226f, 0.905660f, 0.915094f,
+    0.924528f, 0.933962f, 0.943396f, 0.952830f, 0.962264f, 0.971698f, 0.981132f,
+    0.990566f, 1.000000f};
+
+// in_tab and out_tab should contain inccreasing float values
+static float lookup_table(size_t n, const float *in_tab, const float *out_tab,
+                          float val) {
+    if (val < in_tab[0]) return out_tab[0];
+
+    for (size_t j = 1; j < n; j++) {
+        if (val < in_tab[j]) {
+            const float dd =
+                (val - in_tab[j - 1]) / (in_tab[j] - in_tab[j - 1]);
+            return out_tab[j - 1] + (out_tab[j] - out_tab[j - 1]) * dd;
+        }
+    }
+
+    return out_tab[n - 1];
+}
+// transform gradient G to R
+float transformToRn(float currG, float detailFactor){
+    const float mult = copysign(1.f, currG);
+    // G to W
+    currG = pow_F(10, (mult * currG) * LOG10FACTOR * detailFactor) - 1.0f;
+    // W to RESP
+    return mult * lookup_table(LOOKUP_W_TO_R, W_table, R_table, currG);
 }
 
-namespace {
-const size_t PYRAMID_MIN_PIXELS = 3;
+// transform gradient R to G
+float transformToGn(float currR, float detailFactor){
+    const float mult = copysign(1.f, currR);
+    // RESP to W
+    currR = lookup_table(LOOKUP_W_TO_R, R_table, W_table, mult * currR);
+    // W to G
+    return mult * std::log1p(currR) * detailFactor;
+}
+
+static const float detectT = 0.001f;
+static const float a = 0.038737f;
+static const float b = 0.537756f;
+
+//! \brief compute a scale factor based on the input \a g value
+float calculateScaleFactor(float g) {
+    return 1.0 / (a * pow_F(std::max(detectT, std::fabs(g)), b));
+}
+
 }
 
 PyramidT::PyramidT(size_t rows, size_t cols) : m_rows(rows), m_cols(cols) {
@@ -127,15 +209,6 @@ void PyramidT::computeSumOfDivergence(pfs::Array2Df &sumOfdivG) {
     }
 }
 
-namespace {
-struct CalculateScaleFactor {
-    XYGradient operator()(const XYGradient &xyGrad) const {
-        return XYGradient(calculateScaleFactor(xyGrad.gX()),
-                          calculateScaleFactor(xyGrad.gY()));
-    }
-};
-}
-
 void PyramidT::computeScaleFactors(PyramidT &result) const {
     PyramidContainer::const_iterator inCurr = m_pyramid.begin();
     PyramidContainer::const_iterator inEnd = m_pyramid.end();
@@ -143,53 +216,60 @@ void PyramidT::computeScaleFactors(PyramidT &result) const {
     PyramidContainer::iterator outCurr = result.m_pyramid.begin();
 
     while (inCurr != inEnd) {
-        std::transform(inCurr->begin(), inCurr->end(), outCurr->begin(),
-                       CalculateScaleFactor());
+        #pragma omp parallel for
+        for(int i = 0; i < inCurr->getRows(); i++) {
+            PyramidS::const_iterator currGxy = inCurr->row_begin(i);
+            PyramidS::const_iterator endGxy = inCurr->row_end(i);
+            PyramidS::iterator currGxyOut = outCurr->row_begin(i);
 
-        ++outCurr;
+            while (currGxy != endGxy) {
+                currGxyOut->gX() = calculateScaleFactor(currGxy->gX());
+                currGxyOut->gY() = calculateScaleFactor(currGxy->gY());
+                ++currGxy;
+                ++currGxyOut;
+            }
+        }
         ++inCurr;
+        ++outCurr;
     }
-}
-
-namespace {
-template <typename Traits>
-struct TransformObj {
-    TransformObj(float f) : t_(f) {}
-
-    XYGradient operator()(const XYGradient &xyGrad) const {
-        return XYGradient(t_(xyGrad.gX()), t_(xyGrad.gY()));
-    }
-
-   private:
-    Traits t_;
-};
 }
 
 void PyramidT::transformToR(float detailFactor) {
     PyramidContainer::iterator itCurr = m_pyramid.begin();
     PyramidContainer::iterator itEnd = m_pyramid.end();
 
-    TransformObj<TransformToR> transformFunctor(detailFactor);
-
     while (itCurr != itEnd) {
-        std::transform(itCurr->begin(), itCurr->end(), itCurr->begin(),
-                       transformFunctor);
+        #pragma omp parallel for
+        for(int i = 0; i < itCurr->getRows(); i++) {
+            PyramidS::iterator currGxy = itCurr->row_begin(i);
+            PyramidS::iterator endGxy = itCurr->row_end(i);
 
+            while (currGxy != endGxy) {
+                currGxy->gX() = transformToRn(currGxy->gX(), detailFactor);
+                currGxy->gY() = transformToRn(currGxy->gY(), detailFactor);
+                ++currGxy;
+            }
+        }
         ++itCurr;
     }
 }
 
 void PyramidT::transformToG(float detailFactor) {
-BENCHFUN
     PyramidContainer::iterator itCurr = m_pyramid.begin();
     PyramidContainer::iterator itEnd = m_pyramid.end();
 
-    TransformObj<TransformToG> transformFunctor(detailFactor);
-
     while (itCurr != itEnd) {
-        std::transform(itCurr->begin(), itCurr->end(), itCurr->begin(),
-                       transformFunctor);
+        #pragma omp parallel for
+        for(int i = 0; i < itCurr->getRows(); i++) {
+            PyramidS::iterator currGxy = itCurr->row_begin(i);
+            PyramidS::iterator endGxy = itCurr->row_end(i);
 
+            while (currGxy != endGxy) {
+                currGxy->gX() = transformToGn(currGxy->gX(), detailFactor);
+                currGxy->gY() = transformToGn(currGxy->gY(), detailFactor);
+                ++currGxy;
+            }
+        }
         ++itCurr;
     }
 }
@@ -464,92 +544,6 @@ void calculateGradients(const float *inputData, PyramidS &gradient) {
     }      // pragma omp parallel
 }
 
-namespace {
-const float LOG10FACTOR = 2.3025850929940456840179914546844f;
-const size_t LOOKUP_W_TO_R = 107;
-
-static float W_table[] = {
-    0.000000f,    0.010000f,    0.021180f,    0.031830f,    0.042628f,
-    0.053819f,    0.065556f,    0.077960f,    0.091140f,    0.105203f,
-    0.120255f,    0.136410f,    0.153788f,    0.172518f,    0.192739f,
-    0.214605f,    0.238282f,    0.263952f,    0.291817f,    0.322099f,
-    0.355040f,    0.390911f,    0.430009f,    0.472663f,    0.519238f,
-    0.570138f,    0.625811f,    0.686754f,    0.753519f,    0.826720f,
-    0.907041f,    0.995242f,    1.092169f,    1.198767f,    1.316090f,
-    1.445315f,    1.587756f,    1.744884f,    1.918345f,    2.109983f,
-    2.321863f,    2.556306f,    2.815914f,    3.103613f,    3.422694f,
-    3.776862f,    4.170291f,    4.607686f,    5.094361f,    5.636316f,
-    6.240338f,    6.914106f,    7.666321f,    8.506849f,    9.446889f,
-    10.499164f,   11.678143f,   13.000302f,   14.484414f,   16.151900f,
-    18.027221f,   20.138345f,   22.517282f,   25.200713f,   28.230715f,
-    31.655611f,   35.530967f,   39.920749f,   44.898685f,   50.549857f,
-    56.972578f,   64.280589f,   72.605654f,   82.100619f,   92.943020f,
-    105.339358f,  119.530154f,  135.795960f,  154.464484f,  175.919088f,
-    200.608905f,  229.060934f,  261.894494f,  299.838552f,  343.752526f,
-    394.651294f,  453.735325f,  522.427053f,  602.414859f,  695.706358f,
-    804.693100f,  932.229271f,  1081.727632f, 1257.276717f, 1463.784297f,
-    1707.153398f, 1994.498731f, 2334.413424f, 2737.298517f, 3215.770944f,
-    3785.169959f, 4464.187290f, 5275.653272f, 6247.520102f, 7414.094945f,
-    8817.590551f, 10510.080619f};
-static float R_table[] = {
-    0.000000f, 0.009434f, 0.018868f, 0.028302f, 0.037736f, 0.047170f, 0.056604f,
-    0.066038f, 0.075472f, 0.084906f, 0.094340f, 0.103774f, 0.113208f, 0.122642f,
-    0.132075f, 0.141509f, 0.150943f, 0.160377f, 0.169811f, 0.179245f, 0.188679f,
-    0.198113f, 0.207547f, 0.216981f, 0.226415f, 0.235849f, 0.245283f, 0.254717f,
-    0.264151f, 0.273585f, 0.283019f, 0.292453f, 0.301887f, 0.311321f, 0.320755f,
-    0.330189f, 0.339623f, 0.349057f, 0.358491f, 0.367925f, 0.377358f, 0.386792f,
-    0.396226f, 0.405660f, 0.415094f, 0.424528f, 0.433962f, 0.443396f, 0.452830f,
-    0.462264f, 0.471698f, 0.481132f, 0.490566f, 0.500000f, 0.509434f, 0.518868f,
-    0.528302f, 0.537736f, 0.547170f, 0.556604f, 0.566038f, 0.575472f, 0.584906f,
-    0.594340f, 0.603774f, 0.613208f, 0.622642f, 0.632075f, 0.641509f, 0.650943f,
-    0.660377f, 0.669811f, 0.679245f, 0.688679f, 0.698113f, 0.707547f, 0.716981f,
-    0.726415f, 0.735849f, 0.745283f, 0.754717f, 0.764151f, 0.773585f, 0.783019f,
-    0.792453f, 0.801887f, 0.811321f, 0.820755f, 0.830189f, 0.839623f, 0.849057f,
-    0.858491f, 0.867925f, 0.877358f, 0.886792f, 0.896226f, 0.905660f, 0.915094f,
-    0.924528f, 0.933962f, 0.943396f, 0.952830f, 0.962264f, 0.971698f, 0.981132f,
-    0.990566f, 1.000000f};
-
-// in_tab and out_tab should contain inccreasing float values
-static float lookup_table(size_t n, const float *in_tab, const float *out_tab,
-                          float val) {
-    if (val < in_tab[0]) return out_tab[0];
-
-    for (size_t j = 1; j < n; j++) {
-        if (val < in_tab[j]) {
-            const float dd =
-                (val - in_tab[j - 1]) / (in_tab[j] - in_tab[j - 1]);
-            return out_tab[j - 1] + (out_tab[j] - out_tab[j - 1]) * dd;
-        }
-    }
-
-    return out_tab[n - 1];
-}
-}
-
-TransformToR::TransformToR(float detailFactor)
-    : m_detailFactor(LOG10FACTOR * detailFactor) {}
-
-// transform gradient G to R
-float TransformToR::operator()(float currG) const {
-    const float mult = copysign(1.f, currG);
-    // G to W
-    currG = pow_F(10, (mult * currG) * m_detailFactor) - 1.0f;
-    // W to RESP
-    return mult * lookup_table(LOOKUP_W_TO_R, W_table, R_table, currG);
-}
-
-TransformToG::TransformToG(float detailFactor)
-    : m_detailFactor(1.0f / (LOG10FACTOR * detailFactor)) {}
-
-// transform from R to G
-float TransformToG::operator()(float currR) const {
-    const float mult = copysign(1.f, currR);
-    // RESP to W
-    currR = lookup_table(LOOKUP_W_TO_R, R_table, W_table, mult * currR);
-    // W to G
-    return mult * xlogf(1.f + currR) * m_detailFactor;
-}
-
 //! \brief calculate divergence of two gradient maps (Gx and Gy)
 //! divG(x,y) = [Gx(x,y) - Gx(x-1,y)] + [Gy(x,y) - Gy(x,y-1)]
 //! \note \a divG will be used purely as a temporary vector of data, to store
@@ -563,8 +557,7 @@ void calculateAndAddDivergence(const PyramidS &G, float *divG) {
     divG[0] += G[0][0].gX() + G[0][0].gY();  // OUT
 
     float divGx, divGy;
-// ky = 0
-#pragma omp parallel for private(divGx, divGy)
+
     for (int kx = 1; kx < COLS; kx++) {
         divGx = G[0][kx].gX() - G[0][kx - 1].gX();
         divGy = G[0][kx].gY();
@@ -584,23 +577,4 @@ void calculateAndAddDivergence(const PyramidS &G, float *divG) {
             divG[kx + ky * COLS] += divGx + divGy;  // OUT
         }
     }
-}
-
-namespace {
-//  static const float GFIXATE = 0.1f;
-//  static const float EDGE_WEIGHT = 0.01f;
-static const float detectT = 0.001f;
-static const float a = 0.038737f;
-static const float b = 0.537756f;
-}
-
-float calculateScaleFactor(float g) {
-#if 1
-    return 1.0 / (a * pow_F(std::max(detectT, std::fabs(g)), b));
-#else
-    if (std::fabs(G[i]) < GFIXATE)
-        C[i] = 1.0f / EDGE_WEIGHT;
-    else
-        C[i] = 1.0f;
-#endif
 }

--- a/src/TonemappingOperators/mantiuk06/pyramid.h
+++ b/src/TonemappingOperators/mantiuk06/pyramid.h
@@ -145,25 +145,4 @@ void calculateGradients(const float *inputData, PyramidS &gradient);
 //
 void calculateAndAddDivergence(const PyramidS &G, float *divG);
 
-//! \brief compute a scale factor based on the input \a g value
-float calculateScaleFactor(float g);
-
-//! \brief transform gradient \a G to R
-struct TransformToR {
-    TransformToR(float detailFactor);
-    float operator()(float currG) const;
-
-   private:
-    float m_detailFactor;
-};
-
-//! \brief transform from \a R to G
-struct TransformToG {
-    TransformToG(float detailFactor);
-    float operator()(float currR) const;
-
-   private:
-    float m_detailFactor;
-};
-
 #endif  // MANTIUK06_PYRAMID_H


### PR DESCRIPTION
Here's a first speedup for mantiuk06 tmo
I measured on my rusty AMD FX8350 8-core using a 24 MP file with default settings for mantiuk06.

```
Old code: ~44.4 seconds
New code: ~22.3 seconds
```

I will try to make it even faster next days.

Edit: Forgot to mention that I also improved the progress bar for mantiuk06.