### PR TITLE
macOS: INSTALL: LHDR version 2.5.1 --> 2.5.2

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -172,7 +172,7 @@ $ make
 
 Caution 1:
 If you crash on start up with a message about libz.1.2.8.dylib, modify the executable as follows:
-$ install_name_tool -change @loader_path/libz.1.2.8.dylib @loader_path/libz.1.dylib Luminance\ HDR\ 2.5.1.app/Contents/MacOS/Luminance\ HDR\ 2.5.1
+$ install_name_tool -change @loader_path/libz.1.2.8.dylib @loader_path/libz.1.dylib Luminance\ HDR\ 2.5.2.app/Contents/MacOS/Luminance\ HDR\ 2.5.2
 
 Caution 2:
 If you built libboost from source, you may encounter errors from macdeployqt about missing libraries.
@@ -180,7 +180,7 @@ Copy the boost libraries to /usr/lib
 $ sudo cp /usr/local/*boost*.dylib /usr/lib
 
 Copy Qt frameworks and dynamic libraries into the bundle:
-$ $QT/bin/macdeployqt  Luminance\ HDR\ 2.5.1.app/ -executable=Luminance\ HDR\ 2.5.1.app/Contents/MacOS/luminance-hdr-cli -no-strip -always-overwrite
+$ $QT/bin/macdeployqt  Luminance\ HDR\ 2.5.2.app/ -executable=Luminance\ HDR\ 2.5.2.app/Contents/MacOS/luminance-hdr-cli -no-strip -always-overwrite
 
 Caution:  This may produce the following warnings (which you may ignore) such as:
 WARNING: Plugin "libqsqlodbc.dylib" uses private API and is not Mac App store compliant.
@@ -189,7 +189,7 @@ ERROR: no file at "/opt/local/lib/mysql55/mysql/libmysqlclient.18.dylib"
 ERROR: no file at "/usr/local/lib/libpq.5.dylib"
 
 If you wish to make a DMG (optional)
-$ hdiutil create -ov -srcfolder Luminance\ HDR\ 2.5.1.app Luminance\ HDR\ 2.5.1.dmg
+$ hdiutil create -ov -srcfolder Luminance\ HDR\ 2.5.2.app Luminance\ HDR\ 2.5.2.dmg
 
 If you wish to build with an earlier version of the MacOS-X Platform SDK (eg 10.9), use the following:
 


### PR DESCRIPTION
Instructions are updated to work with LHDR "2.5.2" version.