### PR TITLE
Add Retina support for macOS/OS X

### DIFF
--- a/build_files/platforms/macosx/Info.plist.in
+++ b/build_files/platforms/macosx/Info.plist.in
@@ -20,6 +20,8 @@
         <string>@LHDR_NAME@</string>
         <key>LSMinimumSystemVersion</key>
         <string>@CMAKE_OSX_DEPLOYMENT_TARGET@</string>
+        <key>NSHighResolutionCapable</key>
+        <string>True</string>
         <key>NOTE</key>
         <string>Created by Davide Anastasia &lt;davideanastasia@users.sourceforge.net&gt;</string>
     </dict>


### PR DESCRIPTION
Simply adding the NSHighResolutionCapable key, set to True, to the
Info.plist file allows proper rendering on retina displays.