### PR TITLE
Mac: put 4 files in /Contents directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,7 +311,7 @@ IF(APPLE)
          ${CMAKE_SOURCE_DIR}/README.md
          ${CMAKE_SOURCE_DIR}/LICENSE
          ${CMAKE_SOURCE_DIR}/Changelog
-         DESTINATION ${LHDR_OSX_EXECUTABLE_NAME}.app
+         DESTINATION ${LHDR_OSX_EXECUTABLE_NAME}.app/Contents
     )
 
 # Unix


### PR DESCRIPTION
Instead of the root .app directory.
All contents of a bundle should be in `/Contents` per Apple https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFBundles/BundleTypes/BundleTypes.html
 
   "At the top-level of the bundle is a directory named Contents. This directory contains everything, including the resources, executable code, private frameworks, private plug-ins, and support files needed by the application. While the Contents directory might seem superfluous, it identifies the bundle as a modern-style bundle and separates it from document and legacy bundle types found in earlier versions of Mac OS."

This enables the use of the `codesign` command on the app.