### PR TITLE
Define EXIV2_TEST_VERSION by including exiv2.hpp

### DIFF
--- a/src/TransplantExif/TransplantExifDialog.cpp
+++ b/src/TransplantExif/TransplantExifDialog.cpp
@@ -26,6 +26,7 @@
 #include <QMessageBox>
 #include <exif.hpp>
 #include <image.hpp>
+#include <exiv2/exiv2.hpp>
 
 #include "Common/config.h"
 #include "Common/global.h"


### PR DESCRIPTION
AppleClang 10 did not allow compilation without `exiv2/exiv2.hpp` or `exiv2/version.hpp` 
Also, `version.hpp` says use `exiv2.hpp`