### PR TITLE
Mac/INSTALL: openmp cmake flags

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -172,6 +172,22 @@ $ cd build
 $ cmake .. -DCMAKE_PREFIX_PATH=$(echo $QT/lib/cmake/* | sed -Ee 's$ $;$g')
 $ make
 
+Enabling OpenMP on macOS:
+As AppleClang requires preprocessing to detect OpenMP, the cmake command to enable AppleClang 10+ to use the libiomp5 implementation would be:
+$ cmake -DCMAKE_OSX_DEPLOYMENT_TARGET="10.9" \
+-DCMAKE_PREFIX_PATH=$(echo $QT/lib/cmake/* | sed -Ee 's$ $;$g') -G "Unix Makefiles" \
+-DCMAKE_C_COMPILER="clang" \
+-DCMAKE_CXX_COMPILER="clang++" \
+-DCMAKE_BUILD_TYPE=Release \
+-DOpenMP_C_FLAGS=-fopenmp=lomp \
+-DOpenMP_CXX_FLAGS=-fopenmp=lomp \
+-DOpenMP_C_LIB_NAMES="libiomp5" \
+-DOpenMP_CXX_LIB_NAMES="libiomp5" \
+-DOpenMP_libiomp5_LIBRARY="/opt/local/lib/libiomp5.dylib" \
+-DOpenMP_CXX_FLAGS="-Xpreprocessor -fopenmp /opt/local/lib/libiomp5.dylib -I/opt/local/include" \
+-DOpenMP_CXX_LIB_NAMES="libiomp5" \
+-DOpenMP_C_FLAGS="-Xpreprocessor -fopenmp /opt/local/lib/libiomp5.dylib -I/opt/local/include" 
+
 Caution 1:
 If you crash on start up with a message about libz.1.2.8.dylib, modify the executable as follows:
 $ install_name_tool -change @loader_path/libz.1.2.8.dylib @loader_path/libz.1.dylib Luminance\ HDR\ 2.5.2.app/Contents/MacOS/Luminance\ HDR\ 2.5.2


### PR DESCRIPTION
Example OpenMP flags that I use when building LHDR with AppleClang 10.0000+.  [libiomp5](https://www.openmprtl.org/sites/default/files/libomp_20160808_oss.tgz) is an OpenMP 3.1 compliant drop-in replacement for libomp.  