### PR TITLE
ExifOperations: include exiv2/exiv2.hpp

### DIFF
--- a/src/Exif/ExifOperations.cpp
+++ b/src/Exif/ExifOperations.cpp
@@ -35,6 +35,7 @@
 #include <boost/assign/list_of.hpp>
 
 #include <exif.hpp>
+#include <exiv2/exiv2.hpp>
 #include <image.hpp>
 
 #include "Common/config.h"


### PR DESCRIPTION
Because type `AnyError` requires definition in the exiv2 namespace.