### PR TITLE
Add missing conditional (#ifndef NDEBUG) include of cstdio for printf…

### DIFF
--- a/librtprocess/src/include/LUT.h
+++ b/librtprocess/src/include/LUT.h
@@ -63,6 +63,7 @@
 #include <cstdint>
 #ifndef NDEBUG
 #include <cassert>
+#include <cstdio>
 #endif
 #include "opthelper.h"
 #include "rt_math.h"


### PR DESCRIPTION
… in librtprocess/src/include/LUT.h

This fixes:

```
FAILED: librtprocess/CMakeFiles/librtprocess.dir/src/demosaic/markesteijn.cc.o 
/usr/lib64/ccache/c++ -DBRANCH_PREDICTION -DHAVE_CFITSIO -DHAVE_FFTW3F -DHAVE_INLINE -DLHDR_CXX11_ENABLED -Ilibrtprocess -I../librtprocess -I../src -Isrc -I. -I../librtprocess/src/include -I/usr/include/libraw -I/usr/include/eigen3 -I/usr/include/exiv2 -I/usr/include/OpenEXR -I/usr/include/cfitsio -fopenmp -g -fPIC   -Wall -Wno-unknown-pragmas -Wno-deprecated -Wno-deprecated-declarations -std=gnu++11 -MD -MT librtprocess/CMakeFiles/librtprocess.dir/src/demosaic/markesteijn.cc.o -MF librtprocess/CMakeFiles/librtprocess.dir/src/demosaic/markesteijn.cc.o.d -o librtprocess/CMakeFiles/librtprocess.dir/src/demosaic/markesteijn.cc.o -c ../librtprocess/src/demosaic/markesteijn.cc
In file included from ../librtprocess/src/demosaic/markesteijn.cc:26:
../librtprocess/src/include/LUT.h: In constructor ‘LUT<T>::LUT(int, int, bool)’:
../librtprocess/src/include/LUT.h:114:13: error: there are no arguments to ‘printf’ that depend on a template parameter, so a declaration of ‘printf’ must be available [-fpermissive]
  114 |             printf("s<=0!\n");
      |             ^~~~~~
../librtprocess/src/include/LUT.h:114:13: note: (if you use ‘-fpermissive’, G++ will accept your code, but allowing the use of an undeclared name is deprecated)
../librtprocess/src/include/LUT.h: In member function ‘void LUT<T>::operator()(int, int, bool)’:
../librtprocess/src/include/LUT.h:144:13: error: there are no arguments to ‘printf’ that depend on a template parameter, so a declaration of ‘printf’ must be available [-fpermissive]
  144 |             printf("s<=0!\n");
      |             ^~~~~~
../librtprocess/src/include/LUT.h: In instantiation of ‘LUT<T>::LUT(int, int, bool) [with T = float]’:
../librtprocess/src/demosaic/markesteijn.cc:49:29:   required from here
../librtprocess/src/include/LUT.h:114:19: error: ‘printf’ was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
  114 |             printf("s<=0!\n");
      |             ~~~~~~^~~~~~~~~~~
In file included from /usr/include/c++/10/cstdio:42,
                 from /usr/include/c++/10/ext/string_conversions.h:43,
                 from /usr/include/c++/10/bits/basic_string.h:6545,
                 from /usr/include/c++/10/string:55,
                 from /usr/include/c++/10/bits/locale_classes.h:40,
                 from /usr/include/c++/10/bits/ios_base.h:41,
                 from /usr/include/c++/10/ios:42,
                 from /usr/include/c++/10/ostream:38,
                 from /usr/include/c++/10/iostream:39,
                 from ../src/StopWatch.h:24,
                 from ../librtprocess/src/demosaic/markesteijn.cc:30:
/usr/include/stdio.h:332:12: note: ‘int printf(const char*, ...)’ declared here, later in the translation unit
  332 | extern int printf (const char *__restrict __format, ...);
      |            ^~~~~~
```