### PR TITLE
Link missing “common” library to TestPoissonSolver

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -187,7 +187,7 @@ ENDIF()
 TARGET_LINK_LIBRARIES(TestFusionOperator Qt5::Core Qt5::Gui Qt5::Widgets)
 
 ADD_EXECUTABLE(TestPoissonSolver TestPoissonSolver.cpp)
-TARGET_LINK_LIBRARIES(TestPoissonSolver hdrwizard pfs pfstmo 
+TARGET_LINK_LIBRARIES(TestPoissonSolver hdrwizard pfs pfstmo common
     ${GTEST_BOTH_LIBRARIES}
     ${CMAKE_THREAD_LIBS_INIT}
     ${LIBS})


### PR DESCRIPTION
This fixes:

```
FAILED: test/TestPoissonSolver 
: && /usr/lib64/ccache/c++ -fopenmp -g -rdynamic test/CMakeFiles/TestPoissonSolver.dir/TestPoissonSolver.cpp.o -o test/TestPoissonSolver  src/HdrWizard/libhdrwizard.a  src/Libpfs/libpfs.a  src/TonemappingOperators/libpfstmo.a  /usr/lib64/libgtest.so  /usr/lib64/libgtest_main.so  /usr/lib64/libcfitsio.so  /usr/lib64/libHalf.so  /usr/lib64/libIex.so  /usr/lib64/libIlmImf.so  /usr/lib64/libIlmThread.so  /usr/lib64/libImath.so  /usr/lib64/libtiff.so  /usr/lib64/libraw_r.so  /usr/lib64/libfftw3f.so  /usr/lib64/libfftw3f_threads.so  /usr/lib64/libgsl.so  /usr/lib64/libgslcblas.so  /usr/lib64/libexiv2.so  /usr/lib64/libjpeg.so  /usr/lib64/liblcms2.so  /usr/lib64/libpng.so  /usr/lib64/libz.so  /usr/lib64/libboost_program_options.so  -lboost_thread  /usr/lib64/libboost_chrono.so  /usr/lib64/libboost_system.so  /usr/lib64/libboost_date_time.so  /usr/lib64/libboost_atomic.so  /usr/lib64/libQt5Concurrent.so.5.15.2  /usr/lib64/libQt5Sql.so.5.15.2  /usr/lib64/libQt5Widgets.so.5.15.2  /usr/lib64/libQt5Gui.so.5.15.2  /usr/lib64/libQt5Core.so.5.15.2 && :
/usr/bin/ld: src/HdrWizard/libhdrwizard.a(AutoAntighosting.cpp.o): in function `solve_pde_dct(pfs::Array2D<float>&, pfs::Array2D<float>&)':
/home/ben/src/forks/LuminanceHDR/build/../src/HdrWizard/AutoAntighosting.cpp:58: undefined reference to `init_fftw()'
/usr/bin/ld: /home/ben/src/forks/LuminanceHDR/build/../src/HdrWizard/AutoAntighosting.cpp:66: undefined reference to `FFTW_MUTEX::fftw_mutex_plan'
/usr/bin/ld: /home/ben/src/forks/LuminanceHDR/build/../src/HdrWizard/AutoAntighosting.cpp:70: undefined reference to `FFTW_MUTEX::fftw_mutex_plan'
/usr/bin/ld: /home/ben/src/forks/LuminanceHDR/build/../src/HdrWizard/AutoAntighosting.cpp:114: undefined reference to `FFTW_MUTEX::fftw_mutex_destroy_plan'
/usr/bin/ld: /home/ben/src/forks/LuminanceHDR/build/../src/HdrWizard/AutoAntighosting.cpp:116: undefined reference to `FFTW_MUTEX::fftw_mutex_destroy_plan'
/usr/bin/ld: src/TonemappingOperators/libpfstmo.a(pde_fft.cpp.o): in function `transform_ev2normal(pfs::Array2D<float>&, pfs::Array2D<float>&)':
/home/ben/src/forks/LuminanceHDR/build/../src/TonemappingOperators/fattal02/pde_fft.cpp:124: undefined reference to `FFTW_MUTEX::fftw_mutex_plan'
/usr/bin/ld: /home/ben/src/forks/LuminanceHDR/build/../src/TonemappingOperators/fattal02/pde_fft.cpp:127: undefined reference to `FFTW_MUTEX::fftw_mutex_plan'
/usr/bin/ld: /home/ben/src/forks/LuminanceHDR/build/../src/TonemappingOperators/fattal02/pde_fft.cpp:131: undefined reference to `FFTW_MUTEX::fftw_mutex_destroy_plan'
/usr/bin/ld: /home/ben/src/forks/LuminanceHDR/build/../src/TonemappingOperators/fattal02/pde_fft.cpp:133: undefined reference to `FFTW_MUTEX::fftw_mutex_destroy_plan'
/usr/bin/ld: src/TonemappingOperators/libpfstmo.a(pde_fft.cpp.o): in function `transform_normal2ev(pfs::Array2D<float>&, pfs::Array2D<float>&)':
/home/ben/src/forks/LuminanceHDR/build/../src/TonemappingOperators/fattal02/pde_fft.cpp:144: undefined reference to `FFTW_MUTEX::fftw_mutex_plan'
/usr/bin/ld: /home/ben/src/forks/LuminanceHDR/build/../src/TonemappingOperators/fattal02/pde_fft.cpp:147: undefined reference to `FFTW_MUTEX::fftw_mutex_plan'
/usr/bin/ld: /home/ben/src/forks/LuminanceHDR/build/../src/TonemappingOperators/fattal02/pde_fft.cpp:151: undefined reference to `FFTW_MUTEX::fftw_mutex_destroy_plan'
/usr/bin/ld: /home/ben/src/forks/LuminanceHDR/build/../src/TonemappingOperators/fattal02/pde_fft.cpp:153: undefined reference to `FFTW_MUTEX::fftw_mutex_destroy_plan'
/usr/bin/ld: src/TonemappingOperators/libpfstmo.a(pde_fft.cpp.o): in function `solve_pde_fft(pfs::Array2D<float>&, pfs::Array2D<float>&, pfs::Array2D<float>&, pfs::Progress&, bool)':
/home/ben/src/forks/LuminanceHDR/build/../src/TonemappingOperators/fattal02/pde_fft.cpp:233: undefined reference to `init_fftw()'
collect2: error: ld returned 1 exit status
```