### PR TITLE
Fix include for std::mutex in init_fftw.h

### DIFF
--- a/src/Common/init_fftw.h
+++ b/src/Common/init_fftw.h
@@ -22,7 +22,7 @@
 #ifndef INIT_FFTW_H
 #define INIT_FFTW_H
 
-#include <boost/thread/mutex.hpp>
+#include <mutex>
 
 class FFTW_MUTEX {
    public:


### PR DESCRIPTION
Fixes #252 