### PR TITLE
Fix under- and over-exposure problems with Debevec

### DIFF
--- a/src/HdrCreation/debevec.cpp
+++ b/src/HdrCreation/debevec.cpp
@@ -141,9 +141,9 @@ void DebevecOperator::computeFusion(ResponseCurve &response,
     #pragma omp parallel for
 #endif
     for (size_t i = 0; i < num_images; i++) {
-        Channel *Ch[channels];
-        images[i].frame()->getXYZChannels(Ch[0], Ch[1], Ch[2]);
-        Array2Df *imagesCh[channels] = {Ch[0], Ch[1], Ch[2]};
+        Channel *Ch_i[channels];
+        images[i].frame()->getXYZChannels(Ch_i[0], Ch_i[1], Ch_i[2]);
+        Array2Df *imagesCh[channels] = {Ch_i[0], Ch_i[1], Ch_i[2]};
 
         int i_darker = idx_darker[i];
         Channel *Ch_dark[channels];
@@ -253,7 +253,7 @@ void DebevecOperator::computeFusion(ResponseCurve &response,
     float cmax[3];
     float cmin[3];
 #ifdef _OPENMP
-    #pragma omp parallel for num_threads(nestedthreads) if (nestedthreads>1)
+    #pragma omp parallel for
 #endif
     for (int c = 0; c < channels; c++) {
         float minval = numeric_limits<float>::max();
@@ -298,7 +298,7 @@ void DebevecOperator::computeFusion(ResponseCurve &response,
     }
 
 #ifdef _OPENMP
-    #pragma omp parallel for num_threads(nestedthreads) if (nestedthreads>1)
+    #pragma omp parallel for
 #endif
     for (int c = 0; c < channels; c++) {
         transform(Ch[c]->begin(), Ch[c]->end(), Ch[c]->begin(),


### PR DESCRIPTION
Similar fix as was implemented for Robertson in pull request #233. The only major difference is that it considers the worst case across all channels, because Debevec uses a single weight per pixel instead of a separate weight per channel.

Gets rid of dark suns, ugly halos, blotches, fuzz caused by compression artifacts, and weird colors in areas that are over-exposed in one or more of the images.
Also gets rid of white pixels when the brightest image still has pure black pixels (which lead to a weight of zero that was used in a division operation, and for some reason it was decided that NaN pixels should be white).

Gallery with some after & before images: https://www.dropbox.com/sh/f0tyoa5m9s56dxm/AAAf07WYMmBt6gzlDLzMqdi0a?dl=0
