### PR TITLE
Fix deprecated top-level developer_name in AppData XML

### DIFF
--- a/net.sourceforge.qtpfsgui.LuminanceHDR.appdata.xml
+++ b/net.sourceforge.qtpfsgui.LuminanceHDR.appdata.xml
@@ -39,7 +39,9 @@
     <binary>luminance-hdr-cli</binary>
   </provides>
 
-  <developer_name>Luminance HDR Development Team</developer_name>
+  <developer>
+    <name>Luminance HDR Development Team</name>
+  </developer>
   <update_contact>fcomida_AT_users.sourceforge.net</update_contact>
   <url type="homepage">http://qtpfsgui.sourceforge.net/</url>
   <url type="help">https://luminancehdr.readthedocs.io/en/latest/</url>

--- a/net.sourceforge.qtpfsgui.LuminanceHDR.appdata.xml
+++ b/net.sourceforge.qtpfsgui.LuminanceHDR.appdata.xml
@@ -39,7 +39,7 @@
     <binary>luminance-hdr-cli</binary>
   </provides>
 
-  <developer>
+  <developer id="net.sourceforge.qtpfsgui">
     <name>Luminance HDR Development Team</name>
   </developer>
   <update_contact>fcomida_AT_users.sourceforge.net</update_contact>


### PR DESCRIPTION
Use the `name` element in a `developer` block instead, as recommended by `appstreamcli` 1.0.0.

This fixes all warnings when validating the AppData XML file, although there are still informational messages:

```
I: net.sourceforge.qtpfsgui.LuminanceHDR:20: screenshot-media-url-not-secure
     http://qtpfsgui.sourceforge.net/screenshots/MainWindow.png
   Consider using a secure (HTTPS) URL to reference this screenshot image or video.

I: net.sourceforge.qtpfsgui.LuminanceHDR:24: screenshot-media-url-not-secure
     http://qtpfsgui.sourceforge.net/screenshots/Tonemapped-image.png
   Consider using a secure (HTTPS) URL to reference this screenshot image or video.

I: net.sourceforge.qtpfsgui.LuminanceHDR:28: screenshot-media-url-not-secure
     http://qtpfsgui.sourceforge.net/screenshots/HDR-Wizard-1st-page.png
   Consider using a secure (HTTPS) URL to reference this screenshot image or video.

I: net.sourceforge.qtpfsgui.LuminanceHDR:32: screenshot-media-url-not-secure
     http://qtpfsgui.sourceforge.net/screenshots/Batch-TM.png
   Consider using a secure (HTTPS) URL to reference this screenshot image or video.

I: net.sourceforge.qtpfsgui.LuminanceHDR:42: developer-id-missing
   The `developer` element is missing an `id` property, containing a unique string ID for the
   developer. Consider adding a unique ID.

I: net.sourceforge.qtpfsgui.LuminanceHDR:46: url-not-secure http://qtpfsgui.sourceforge.net/
   Consider using a secure (HTTPS) URL for this web link.

✔ Validation was successful: infos: 6, pedantic: 1
```