### PR TITLE
Drop height restriction of advanced editing tools window

### DIFF
--- a/src/HdrWizard/EditingTools.ui
+++ b/src/HdrWizard/EditingTools.ui
@@ -19,7 +19,7 @@
   <property name="maximumSize">
    <size>
     <width>16777215</width>
-    <height>737</height>
+    <height>16777215</height>
    </size>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
Lift the pointless height restriction of the Advanced Editing Tools window to make it more usable on large screens.